### PR TITLE
Remove unexpected Default Game Object in Cave Rule Tile.

### DIFF
--- a/Assets/Tilemap/Rule Tiles/Dungeon Tile/Tile Asset/Cave.asset
+++ b/Assets/Tilemap/Rule Tiles/Dungeon Tile/Tile Asset/Cave.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: Cave
   m_EditorClassIdentifier: 
   m_DefaultSprite: {fileID: 21300032, guid: 5c4f1fa01d076b0448a9438531d30a91, type: 3}
-  m_DefaultGameObject: {fileID: 9160593401528193886, guid: ded228c73cadcf445b1ac399f54c2a97,
-    type: 3}
+  m_DefaultGameObject: {fileID: 0}
   m_DefaultColliderType: 1
   m_TilingRules:
   - m_Neighbors: 01000000020000000200000002000000

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -3,7 +3,7 @@
     "com.unity.2d.pixel-perfect": "1.0.1-preview",
     "com.unity.2d.sprite": "1.0.0",
     "com.unity.2d.tilemap": "1.0.0",
-    "com.unity.2d.tilemap.extras": "https://github.com/Unity-Technologies/2d-extras.git#v1.3.1",
+    "com.unity.2d.tilemap.extras": "https://github.com/Unity-Technologies/2d-extras.git#master",
     "com.unity.ads": "2.3.1",
     "com.unity.analytics": "3.3.2",
     "com.unity.collab-proxy": "1.2.16",
@@ -46,11 +46,5 @@
     "com.unity.modules.vr": "1.0.0",
     "com.unity.modules.wind": "1.0.0",
     "com.unity.modules.xr": "1.0.0"
-  },
-  "lock": {
-    "com.unity.2d.tilemap.extras": {
-      "hash": "de04a1703b0fcbfc5adb9c5390a77d31a0f069ac",
-      "revision": "v1.3.1"
-    }
   }
 }

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -3,7 +3,7 @@
     "com.unity.2d.pixel-perfect": "1.0.1-preview",
     "com.unity.2d.sprite": "1.0.0",
     "com.unity.2d.tilemap": "1.0.0",
-    "com.unity.2d.tilemap.extras": "https://github.com/Unity-Technologies/2d-extras.git#master",
+    "com.unity.2d.tilemap.extras": "https://github.com/Unity-Technologies/2d-extras.git#v1.3.1",
     "com.unity.ads": "2.3.1",
     "com.unity.analytics": "3.3.2",
     "com.unity.collab-proxy": "1.2.16",
@@ -46,5 +46,11 @@
     "com.unity.modules.vr": "1.0.0",
     "com.unity.modules.wind": "1.0.0",
     "com.unity.modules.xr": "1.0.0"
+  },
+  "lock": {
+    "com.unity.2d.tilemap.extras": {
+      "hash": "de04a1703b0fcbfc5adb9c5390a77d31a0f069ac",
+      "revision": "v1.3.1"
+    }
   }
 }


### PR DESCRIPTION
Please check `Assets/Rule Tiles/Dungeon Tile/Tile Asset/Cave`.

When put only one tile in Grid, unexpected SpriteRenderer object is created.

![スクリーンショット 2020-03-28 16 16 11](https://user-images.githubusercontent.com/1229596/77817985-4b9aaf00-7112-11ea-8b7a-7d046ca75389.png)

In `Assets/Rule Tiles/Dungeon Tile/Tile Asset/Cave`, the `Bones_3` is set as Default Game Object.

![スクリーンショット 2020-03-28 16 16 21](https://user-images.githubusercontent.com/1229596/77817991-4e959f80-7112-11ea-97a0-f457ea96e3ae.png)

I think this is unexpected setting.
So, How about remove it?